### PR TITLE
Fix potential UB functions

### DIFF
--- a/src/jumprope.rs
+++ b/src/jumprope.rs
@@ -186,11 +186,11 @@ impl Node {
     }
 
     // The height is at least 1, so this is always valid.
-    pub(super) fn first_next<'a>(&self) -> &'a SkipEntry {
+    pub(super) fn first_next(&self) -> &SkipEntry {
         unsafe { &*self.nexts.as_ptr() }
     }
 
-    fn first_next_mut<'a>(&mut self) -> &'a mut SkipEntry {
+    fn first_next_mut(&mut self) -> &mut SkipEntry {
         unsafe { &mut *self.nexts.as_mut_ptr() }
     }
 


### PR DESCRIPTION
These two function definitions allow the caller to specify a longer
lifetime (ie 'static) than the passed reference to self. Removing
the explicit lifetime ties the two lifetimes together
