### PR TITLE
feat: make iter module accessible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@
 mod jumprope;
 mod gapbuffer;
 mod utils;
-mod iter;
+pub mod iter;
 mod fast_str_tools;
 
 pub use crate::jumprope::JumpRope;


### PR DESCRIPTION
Until TAIT https://github.com/rust-lang/rust/issues/63063 is stabilized, it is impossible to make iterator combinators on top of those exposed by this library.